### PR TITLE
Make tickertape / executions websockets optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ websockets.add_execution_callback { |execution|
 }
 
 websockets.start()
+
+# The tickertape websocket can be optionally disabled when calling start()
+
+websockets = Stockfighter::Websockets.new(gm.config)
+websockets.add_execution_callback { |execution|
+	puts execution
+}
+
+websockets.start(tickertape_enabled:false)
+
+# The executions websocket can also be disabled by passing executions_enabled:false when calling start()
+
 ```
 
 ## Todo

--- a/lib/stockfighter/websockets.rb
+++ b/lib/stockfighter/websockets.rb
@@ -13,7 +13,7 @@ module Stockfighter
       @execution_callbacks = []
     end
 
-    def start() 
+    def start(tickertape_enabled:true, executions_enabled:true)
 
       EM.epoll
       EM.run do
@@ -22,71 +22,85 @@ module Stockfighter
           abort("Error raised during event loop: #{e}")
         }
 
-        tickertape = WebSocket::EventMachine::Client.connect(:uri => "#{WS_URL}/#{@account}/venues/#{@venue}/tickertape", :ssl => true)
-        tickertape.onopen do
-          puts "tickertape websocket: connected"
-        end
-
-        tickertape.onmessage do |msg|
-          incoming = JSON.parse(msg)
-          if not incoming["ok"]
-            raise "tickertape websocket: Error response received: #{msg}"
-          end
-          if incoming.key?('quote')
-            quote = incoming['quote']
-            @quote_callbacks.each { |callback|
-                callback.call(quote)
-            }
-          else
-            raise "tickertape websocket: TODO: Unhandled message type: #{msg}"
-          end
-        end
-
-        tickertape.onerror do |e|
-          puts "tickertape websocket: Error #{e}"
-        end
-
-        tickertape.onping do |msg|
-          puts "tickertape websocket: Received ping: #{msg}"
-        end
-
-        tickertape.onpong do |msg|
-          puts "tickertape websocket: Received pong: #{msg}"
-        end
-
-        tickertape.onclose do |code, reason|
-          raise "tickertape websocket: Client disconnected with status code: #{code} and reason: #{reason}"
-        end
-
-        executions = WebSocket::EventMachine::Client.connect(:uri => "#{WS_URL}/#{@account}/venues/#{@venue}/executions", :ssl => true)
-        executions.onopen do
-          puts "executions websocket: connected"
-        end
-
-        executions.onmessage do |msg|
-          execution = JSON.parse(msg)
-          if not execution["ok"]
-            raise "execution websocket: Error response received: #{msg}"
-          end
-          @execution_callbacks.each { |callback|
-            callback.call(execution)
+        if tickertape_enabled
+          tickertape_options = {
+            :uri => "#{WS_URL}/#{@account}/venues/#{@venue}/tickertape", 
+            :ssl => true
           }
+
+          tickertape = WebSocket::EventMachine::Client.connect(tickertape_options)
+          tickertape.onopen do
+            puts "#{@account} tickertape websocket: connected"
+          end
+
+          tickertape.onmessage do |msg|
+            incoming = JSON.parse(msg)
+            if not incoming["ok"]
+              raise "#{@account} tickertape websocket: Error response received: #{msg}"
+            end
+            if incoming.key?('quote')
+              quote = incoming['quote']
+              @quote_callbacks.each { |callback|
+                  callback.call(quote)
+              }
+            else
+              raise "#{@account} tickertape websocket: TODO: Unhandled message type: #{msg}"
+            end
+          end
+
+          tickertape.onerror do |e|
+            puts "#{@account} tickertape websocket: Error #{e}"
+          end
+
+          tickertape.onping do |msg|
+            puts "#{@account} tickertape websocket: Received ping: #{msg}"
+          end
+
+          tickertape.onpong do |msg|
+            puts "#{@account} tickertape websocket: Received pong: #{msg}"
+          end
+
+          tickertape.onclose do |code, reason|
+            raise "#{@account} tickertape websocket: Client disconnected with status code: #{code} and reason: #{reason}"
+          end
         end
 
-        executions.onerror do |e|
-          puts "executions websocket: Error: #{e}"
-        end
+        if executions_enabled
+          executions_options = {
+            :uri => "#{WS_URL}/#{@account}/venues/#{@venue}/executions", 
+            :ssl => true
+          }
 
-        executions.onping do |msg|
-          puts "executions websocket: Received ping: #{msg}"
-        end
+          executions = WebSocket::EventMachine::Client.connect(executions_options)
+          executions.onopen do
+            puts "#{@account} executions websocket: connected"
+          end
 
-        executions.onpong do |msg|
-          puts "executions websocket: Received pong: #{msg}"
-        end
+          executions.onmessage do |msg|
+            execution = JSON.parse(msg)
+            if not execution["ok"]
+              raise "#{@account} execution websocket: Error response received: #{msg}"
+            end
+            @execution_callbacks.each { |callback|
+              callback.call(execution)
+            }
+          end
 
-        executions.onclose do |code, reason|
-          raise "executions websocket: Client disconnected with status code: #{code} and reason: #{reason}"
+          executions.onerror do |e|
+            puts "#{@account} executions websocket: Error: #{e}"
+          end
+
+          executions.onping do |msg|
+            puts "#{@account} executions websocket: Received ping: #{msg}"
+          end
+
+          executions.onpong do |msg|
+            puts "#{@account} executions websocket: Received pong: #{msg}"
+          end
+
+          executions.onclose do |code, reason|
+            raise "#{@account} executions websocket: Client disconnected with status code: #{code} and reason: #{reason}"
+          end
         end
       end
     end


### PR DESCRIPTION
(both enabled by default)
- Prefix all messages with the account that it is connected to
